### PR TITLE
Enable sharing of text input across screens

### DIFF
--- a/screen_manager/screens.kv
+++ b/screen_manager/screens.kv
@@ -6,6 +6,7 @@ ScreenManagement:
 	
 <WriteMeScreen>:
     name: 'WRITEME.md'
+    input: input
 
     canvas:
         Color:
@@ -19,6 +20,7 @@ ScreenManagement:
             anchor_x: 'center'
             anchor_y: 'top'
             TextInput:
+                id: input
                 text: "Time for some big WRITEME moves!"
                 focus: True
                 size_hint: 1, .9
@@ -57,9 +59,11 @@ ScreenManagement:
                 on_press:
                     root.manager.transition.direction = 'left'
                     root.manager.current = 'README.md'
+                    root.manager.get_screen('README.md').output.text = root.input.text
             
 <ReadMeScreen>:
     name: 'README.md'
+    output: output
 
     canvas:
         Color:
@@ -73,7 +77,7 @@ ScreenManagement:
             anchor_x: 'center'
             anchor_y: 'top'
             TextInput:
-                text: "BOOM!"
+                id: output
                 focus: True
                 size_hint: 1, .9
 


### PR DESCRIPTION
Implement `id` attributes for both screens so as to share text input. Text is shared upon every `on_press` of the `README` button on the `WRITEME` page.